### PR TITLE
Update create_docker_image.yml

### DIFF
--- a/.github/workflows/create_docker_image.yml
+++ b/.github/workflows/create_docker_image.yml
@@ -33,18 +33,7 @@ jobs:
 
     - name: Get version from file
       id: fileVars
-      run: echo "semver=$(cat version.txt)" >> $GITHUB_OUTPUT
-
-    - name: Set up Docker metadata
-      id:   metaVars
-      uses: docker/metadata-action@v5
-      with:
-        # list of Docker images to use as base name for tags
-        images: |
-          ${{ secrets.DOCKERHUB_USERNAME }}/calc
-        # generate Docker tags based on the following events/attributes
-        tags: |
-          type=semver,pattern={{version}}        
+      run: echo "semver=$(cat version.txt)" >> $GITHUB_OUTPUT 
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3  
@@ -59,7 +48,6 @@ jobs:
       uses: docker/build-push-action@v6.2.0
       with:
         push: true
-        # This uses the version we loaded from a file earlier, and labels from the Docker metadata
-        tags: ${{ steps.fileVars.outputs.semver }}
-        labels: ${{ steps.metaVars.outputs.labels }}
+        # This uses the version we loaded from a file earlier (format: user/repo:semver)
+        tags: ${{ secrets.DOCKERHUB_USERNAME }}/calc:${{ steps.fileVars.outputs.semver }}
         


### PR DESCRIPTION
After further debugging, I think this will address the previous failures of CI to build and push the Docker images; I had not realized that what it calls "tags" actually included the user and repo as a part of the tag.